### PR TITLE
now i18n can fallback to en_US if the language file is not in the system

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -22,9 +22,7 @@ exports = function (key, params, language) {
 	try {
     	store = JSON.parse(CACHE['resources/languages/' + language + '.json']);
 	} catch (err) {
-		logger.log("Language " + language + " not in 'resources/languages/' files. Please check.");
-		language = 'en_US';
-		store = JSON.parse(CACHE['resources/languages/en_US.json']);
+		
 	}
 	
     if (store) {


### PR DESCRIPTION
As in line 18, en_US is set as the main language, the function should fallback to en_US.json if the language isn't in the filesystem (CACHE[path/to/json] is undefined);
